### PR TITLE
Fix/developer/git symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-git/gitconfig.local.symlink
+developer/common/git/gitconfig.local.symlink
 zsh/localrc.symlink

--- a/developer/common/git/gitconfig.local.symlink
+++ b/developer/common/git/gitconfig.local.symlink
@@ -1,5 +1,0 @@
-[user]
-        name = pietervanwijk
-        email = hello@pietervanwijk.com
-[credential]
-        helper = osxkeychain

--- a/developer/common/git/gitconfig.local.symlink
+++ b/developer/common/git/gitconfig.local.symlink
@@ -1,5 +1,5 @@
 [user]
-        name = munkius
-        email = snieuwen@gmail.com
+        name = pietervanwijk
+        email = hello@pietervanwijk.com
 [credential]
         helper = osxkeychain


### PR DESCRIPTION
When developers pull this commit, their .gitconfig.local.symlink file will be deleted. When they run script/bootstrap the terminal will ask for their credentials and create a new config file which will be gitignored